### PR TITLE
Add speedometer app

### DIFF
--- a/site/public/speedometer.svg
+++ b/site/public/speedometer.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 20.9 55.6 A 38 38 0 0 1 79.1 55.6" stroke-width="3.5"/>
+  <line x1="20.9" y1="55.6" x2="27.0" y2="60.7" stroke-width="3"/>
+  <line x1="33.9" y1="45.6" x2="37.3" y2="52.8" stroke-width="3"/>
+  <line x1="50" y1="42" x2="50" y2="50" stroke-width="3"/>
+  <line x1="66.1" y1="45.6" x2="62.7" y2="52.8" stroke-width="3"/>
+  <line x1="79.1" y1="55.6" x2="73.0" y2="60.7" stroke-width="3"/>
+  <line x1="50" y1="80" x2="55.6" y2="48.5" stroke-width="2.5"/>
+  <circle cx="50" cy="80" r="4" fill="currentColor" stroke="none"/>
+</svg>

--- a/src/i18n/en-us.ts
+++ b/src/i18n/en-us.ts
@@ -257,6 +257,10 @@ export const enUS: LanguageData = {
     'shared.permissionPrompt.heading': 'Permission Required',
     'shared.prettyInput.close': 'Close Help',
 
+    // Speed
+    'speed.average': 'Average:',
+    'speed.maximum': 'Maximum:',
+
     // Services
     'service.torch.deviceIssue': 'Flashlight issue - reload required',
     'service.wakeLock.released': 'Letting Screen Turn Off',

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from './magnifier-app/magnifier-app.module';
 export * from './nfc-app/nfc-app.module';
 export * from './file-transfer-app/file-transfer-app.module';
 export * from './shared/shared.module';
+export * from './speed-app/speed-app.module';
 export * from './sun-moon-app/sun-moon-app.module';
 export * from './update-pwa/update-pwa.module';
 

--- a/src/services/distance.service.ts
+++ b/src/services/distance.service.ts
@@ -4,6 +4,7 @@ import { DistanceSystem } from '../datatypes/distance-system';
 import { PreferenceService } from './preference.service';
 
 export interface DistanceOptions {
+    omitLabel?: boolean;
     useSmallUnits?: boolean;
     isSpeed?: boolean;
 }
@@ -86,29 +87,41 @@ export class DistanceService {
         if (options.isSpeed) {
             const mph = (feet * 3600) / 5280;
 
-            return `${this._fixed(mph)} mph`;
+            return options.omitLabel
+                ? this._fixed(mph)
+                : `${this._fixed(mph)} mph`;
         }
 
         if (feet < 528 || options.useSmallUnits) {
-            return `${Math.round(feet)} ft`;
+            return options.omitLabel
+                ? String(Math.round(feet))
+                : `${Math.round(feet)} ft`;
         }
 
         const miles = feet / 5280;
 
-        return `${this._fixed(miles)} mi`;
+        return options.omitLabel
+            ? this._fixed(miles)
+            : `${this._fixed(miles)} mi`;
     }
 
     private _toMetric(meters: number, options: DistanceOptions): string {
         if (options.isSpeed) {
-            return `${this._fixed(3.6 * meters)} km/h`;
+            return options.omitLabel
+                ? this._fixed(3.6 * meters)
+                : `${this._fixed(3.6 * meters)} km/h`;
         }
 
         if (meters < 1000 || options.useSmallUnits) {
-            return `${this._fixed(meters)} m`;
+            return options.omitLabel
+                ? this._fixed(meters)
+                : `${this._fixed(meters)} m`;
         }
 
         const kilometers = meters / 1000;
 
-        return `${this._fixed(kilometers)} km`;
+        return options.omitLabel
+            ? this._fixed(kilometers)
+            : `${this._fixed(kilometers)} km`;
     }
 }

--- a/src/speed-app/speed-app.component.ts
+++ b/src/speed-app/speed-app.component.ts
@@ -17,6 +17,10 @@ import { switchMap, takeUntil } from 'rxjs/operators';
 
 @Component('speed-app', {
     style: css`
+        :host {
+            font-size: 1.2em;
+        }
+
         .wrapper {
             display: flex;
             flex-direction: column;

--- a/src/speed-app/speed-app.component.ts
+++ b/src/speed-app/speed-app.component.ts
@@ -1,4 +1,3 @@
-import { AvailabilityState } from '../datatypes/availability-state';
 import { Component, css, html } from 'fudgel';
 import { di } from '../di';
 import {
@@ -11,16 +10,11 @@ import {
     GeolocationCoordinateResultSuccess,
     GeolocationService,
 } from '../services/geolocation.service';
-import { of, Subject } from 'rxjs';
-import { PermissionsService } from '../services/permissions.service';
-import { switchMap, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 @Component('speed-app', {
     style: css`
-        :host {
-            font-size: 1.2em;
-        }
-
         .wrapper {
             display: flex;
             flex-direction: column;
@@ -75,55 +69,53 @@ import { switchMap, takeUntil } from 'rxjs/operators';
         }
     `,
     template: html`
-        <permission-prompt
-            *if="explainAsk"
-            @grant.stop.prevent="grant()"
-            message-id="location.explainAsk"
-        ></permission-prompt>
-        <permission-denied *if="explainDeny"></permission-denied>
-        <location-unavailable *if="explainUnavailable"></location-unavailable>
-        <permission-error *if="explainError"></permission-error>
-        <default-layout *if="showControls">
-            <div class="wrapper">
-                <div class="speed-display">
-                    <grow-to-fit-font-size>{{currentSpeed}}</grow-to-fit-font-size>
-                </div>
-                <div class="speed-info">
-                    <div class="info-item">
-                        <span><i18n-label id="speed.average"></i18n-label></span>
-                        <span>{{averageSpeed}}</span>
+        <location-wrapper>
+            <default-layout>
+                <div class="wrapper">
+                    <div class="speed-display">
+                        <grow-to-fit-font-size
+                            >{{currentSpeed}}</grow-to-fit-font-size
+                        >
                     </div>
-                    <div class="info-item">
-                        <span><i18n-label id="speed.maximum"></i18n-label></span>
-                        <span>{{maximumSpeed}}</span>
+                    <div class="speed-info">
+                        <div class="info-item">
+                            <span
+                                ><i18n-label
+                                    id="speed.average"
+                                ></i18n-label></span
+                            >
+                            <span>{{averageSpeed}}</span>
+                        </div>
+                        <div class="info-item">
+                            <span
+                                ><i18n-label
+                                    id="speed.maximum"
+                                ></i18n-label></span
+                            >
+                            <span>{{maximumSpeed}}</span>
+                        </div>
+                        <pretty-select
+                            i18n-base="info.distances"
+                            value="{{distanceSystem}}"
+                            .options="distanceSystems"
+                            @change="changeDistanceSystem($event.detail)"
+                        ></pretty-select>
                     </div>
-                    <pretty-select
-                        i18n-base="info.distances"
-                        value="{{distanceSystem}}"
-                        .options="distanceSystems"
-                        @change="changeDistanceSystem($event.detail)"
-                    ></pretty-select>
                 </div>
-            </div>
-        </default-layout>
+            </default-layout>
+        </location-wrapper>
     `,
 })
 export class SpeedAppComponent {
     private _distanceService = di(DistanceService);
     private _geolocationService = di(GeolocationService);
     private _lastPosition: GeolocationCoordinateResultSuccess | null = null;
-    private _permissionsService = di(PermissionsService);
     private _subject = new Subject();
     averageSpeed = '';
     currentSpeed = '';
     distanceSystem: DistanceSystem = DistanceSystemDefault;
     distanceSystems = DISTANCE_SYSTEMS;
-    explainAsk = false;
-    explainDeny = false;
-    explainError = false;
-    explainUnavailable = false;
     maximumSpeed = '';
-    showControls = false;
 
     onInit() {
         this._distanceService
@@ -135,29 +127,11 @@ export class SpeedAppComponent {
             });
 
         this._geolocationService
-            .availabilityState()
-            .pipe(
-                takeUntil(this._subject),
-                switchMap((value) => {
-                    this.explainAsk = value === AvailabilityState.PROMPT;
-                    this.explainDeny = value === AvailabilityState.DENIED;
-                    this.explainUnavailable =
-                        value === AvailabilityState.UNAVAILABLE;
-                    this.explainError = value === AvailabilityState.ERROR;
-                    this.showControls = value === AvailabilityState.ALLOWED;
-
-                    if (this.showControls) {
-                        return this._geolocationService.getPositionSuccess();
-                    }
-
-                    return of(null);
-                })
-            )
+            .getPositionSuccess()
+            .pipe(takeUntil(this._subject))
             .subscribe((position) => {
-                if (position) {
-                    this._lastPosition = position;
-                    this._updateDisplay();
-                }
+                this._lastPosition = position;
+                this._updateDisplay();
             });
     }
 
@@ -168,11 +142,6 @@ export class SpeedAppComponent {
 
     changeDistanceSystem(value: DistanceSystem) {
         this._distanceService.setDistanceSystem(value);
-    }
-
-    grant() {
-        this.explainAsk = false;
-        this._permissionsService.geolocation(true);
     }
 
     private _speedNumber(metersPerSecond: number): string {
@@ -201,3 +170,4 @@ export class SpeedAppComponent {
         );
     }
 }
+

--- a/src/speed-app/speed-app.component.ts
+++ b/src/speed-app/speed-app.component.ts
@@ -144,22 +144,15 @@ export class SpeedAppComponent {
         this._distanceService.setDistanceSystem(value);
     }
 
-    private _speedNumber(metersPerSecond: number): string {
-        if (this.distanceSystem === DistanceSystem.IMPERIAL) {
-            const mph = (metersPerSecond * 3.2808398950131 * 3600) / 5280;
-
-            return Math.round(mph).toString();
-        }
-
-        return Math.round(metersPerSecond * 3.6).toString();
-    }
-
     private _updateDisplay() {
         if (!this._lastPosition) {
             return;
         }
 
-        this.currentSpeed = this._speedNumber(this._lastPosition.speed);
+        this.currentSpeed = this._distanceService.metersToString(
+            this._lastPosition.speed,
+            { isSpeed: true, omitLabel: true }
+        );
         this.averageSpeed = this._distanceService.metersToString(
             this._lastPosition.speedSmoothed,
             { isSpeed: true }

--- a/src/speed-app/speed-app.component.ts
+++ b/src/speed-app/speed-app.component.ts
@@ -1,0 +1,199 @@
+import { AvailabilityState } from '../datatypes/availability-state';
+import { Component, css, html } from 'fudgel';
+import { di } from '../di';
+import {
+    DistanceService,
+    DISTANCE_SYSTEMS,
+    DistanceSystemDefault,
+} from '../services/distance.service';
+import { DistanceSystem } from '../datatypes/distance-system';
+import {
+    GeolocationCoordinateResultSuccess,
+    GeolocationService,
+} from '../services/geolocation.service';
+import { of, Subject } from 'rxjs';
+import { PermissionsService } from '../services/permissions.service';
+import { switchMap, takeUntil } from 'rxjs/operators';
+
+@Component('speed-app', {
+    style: css`
+        .wrapper {
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+            height: 100%;
+            width: 100%;
+            overflow: hidden;
+            text-align: center;
+        }
+
+        @media (orientation: landscape) {
+            .wrapper {
+                flex-direction: row;
+            }
+        }
+
+        .speed-display {
+            flex: 2;
+            min-height: 0;
+            min-width: 0;
+        }
+
+        .speed-info {
+            flex: 1;
+            flex-grow: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 0;
+            min-width: 0;
+            gap: 0.3em;
+        }
+
+        .info-item {
+            display: flex;
+            flex-direction: row;
+            gap: 0.4em;
+            align-items: baseline;
+        }
+
+        @media (orientation: landscape) {
+            .speed-info {
+                gap: 0.6em;
+            }
+
+            .info-item {
+                flex-direction: column;
+                gap: 0;
+                align-items: center;
+            }
+        }
+    `,
+    template: html`
+        <permission-prompt
+            *if="explainAsk"
+            @grant.stop.prevent="grant()"
+            message-id="location.explainAsk"
+        ></permission-prompt>
+        <permission-denied *if="explainDeny"></permission-denied>
+        <location-unavailable *if="explainUnavailable"></location-unavailable>
+        <permission-error *if="explainError"></permission-error>
+        <default-layout *if="showControls">
+            <div class="wrapper">
+                <div class="speed-display">
+                    <grow-to-fit-font-size>{{currentSpeed}}</grow-to-fit-font-size>
+                </div>
+                <div class="speed-info">
+                    <div class="info-item">
+                        <span><i18n-label id="speed.average"></i18n-label></span>
+                        <span>{{averageSpeed}}</span>
+                    </div>
+                    <div class="info-item">
+                        <span><i18n-label id="speed.maximum"></i18n-label></span>
+                        <span>{{maximumSpeed}}</span>
+                    </div>
+                    <pretty-select
+                        i18n-base="info.distances"
+                        value="{{distanceSystem}}"
+                        .options="distanceSystems"
+                        @change="changeDistanceSystem($event.detail)"
+                    ></pretty-select>
+                </div>
+            </div>
+        </default-layout>
+    `,
+})
+export class SpeedAppComponent {
+    private _distanceService = di(DistanceService);
+    private _geolocationService = di(GeolocationService);
+    private _lastPosition: GeolocationCoordinateResultSuccess | null = null;
+    private _permissionsService = di(PermissionsService);
+    private _subject = new Subject();
+    averageSpeed = '';
+    currentSpeed = '';
+    distanceSystem: DistanceSystem = DistanceSystemDefault;
+    distanceSystems = DISTANCE_SYSTEMS;
+    explainAsk = false;
+    explainDeny = false;
+    explainError = false;
+    explainUnavailable = false;
+    maximumSpeed = '';
+    showControls = false;
+
+    onInit() {
+        this._distanceService
+            .getCurrentSetting()
+            .pipe(takeUntil(this._subject))
+            .subscribe((system) => {
+                this.distanceSystem = system;
+                this._updateDisplay();
+            });
+
+        this._geolocationService
+            .availabilityState()
+            .pipe(
+                takeUntil(this._subject),
+                switchMap((value) => {
+                    this.explainAsk = value === AvailabilityState.PROMPT;
+                    this.explainDeny = value === AvailabilityState.DENIED;
+                    this.explainUnavailable =
+                        value === AvailabilityState.UNAVAILABLE;
+                    this.explainError = value === AvailabilityState.ERROR;
+                    this.showControls = value === AvailabilityState.ALLOWED;
+
+                    if (this.showControls) {
+                        return this._geolocationService.getPositionSuccess();
+                    }
+
+                    return of(null);
+                })
+            )
+            .subscribe((position) => {
+                if (position) {
+                    this._lastPosition = position;
+                    this._updateDisplay();
+                }
+            });
+    }
+
+    onDestroy() {
+        this._subject.next(null);
+        this._subject.complete();
+    }
+
+    changeDistanceSystem(value: DistanceSystem) {
+        this._distanceService.setDistanceSystem(value);
+    }
+
+    grant() {
+        this.explainAsk = false;
+        this._permissionsService.geolocation(true);
+    }
+
+    private _speedNumber(metersPerSecond: number): string {
+        if (this.distanceSystem === DistanceSystem.IMPERIAL) {
+            const mph = (metersPerSecond * 3.2808398950131 * 3600) / 5280;
+
+            return Math.round(mph).toString();
+        }
+
+        return Math.round(metersPerSecond * 3.6).toString();
+    }
+
+    private _updateDisplay() {
+        if (!this._lastPosition) {
+            return;
+        }
+
+        this.currentSpeed = this._speedNumber(this._lastPosition.speed);
+        this.averageSpeed = this._distanceService.metersToString(
+            this._lastPosition.speedSmoothed,
+            { isSpeed: true }
+        );
+        this.maximumSpeed = this._distanceService.metersToString(
+            this._lastPosition.speedMax,
+            { isSpeed: true }
+        );
+    }
+}

--- a/src/speed-app/speed-app.module.ts
+++ b/src/speed-app/speed-app.module.ts
@@ -1,0 +1,1 @@
+export * from './speed-app.component';

--- a/src/tile-defs.ts
+++ b/src/tile-defs.ts
@@ -119,10 +119,12 @@ export const tileDefs: TileDef[] = [
     },
     {
         id: 'speed',
-        icon: '/speed.svg',
+        icon: '/speedometer.svg',
         label: 'tile.speed',
         component: 'speed-app',
-        show: of(false),
+        show: geolocationService
+            .availabilityState()
+            .pipe(availabilityToBoolean),
     },
     {
         id: 'level',


### PR DESCRIPTION
Adds a speedometer app that displays GPS speed in a large font with average and maximum below.

## Layout

- **2/3 of screen**: Current speed as a large integer in `grow-to-fit-font-size`
- **1/3 of screen**: Average speed, maximum speed, and unit selector
- **Portrait**: Each info item on one line (`Average: 37 mph`)
- **Landscape**: Label on one line, value below — centered vertically

## Data sources (from `GeolocationService`)

- **Current speed**: `position.speed` — raw GPS speed (or calculated from last two positions)
- **Average**: `position.speedSmoothed` — exponentially weighted moving average
- **Maximum**: `position.speedMax` — unsmoothed maximum speed

## Units

Reuses the same `pretty-select` + `DISTANCE_SYSTEMS` + `info.distances` i18n as the Info preferences page. Updating the unit selector here also updates it app-wide (shared `DistanceService`). Display recomputes immediately when the system changes.

## Files changed

- `src/speed-app/speed-app.component.ts` — main component
- `src/speed-app/speed-app.module.ts` — module export
- `site/public/speedometer.svg` — new line-art stroke-based icon (arc, ticks, needle, hub; `stroke="currentColor"`)
- `src/tile-defs.ts` — speed tile now shows when geolocation is available; icon updated to `speedometer.svg`
- `src/index.ts` — registers speed-app module
- `src/i18n/en-us.ts` — adds `speed.average` and `speed.maximum` strings